### PR TITLE
style: fix rustfmt and clippy warnings

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -50,20 +50,19 @@ pub fn main() -> ExitCode {
         ),
         Err(_) => (false, false, false, None, None, None, None),
     };
-    let otel_config = Some(crate::cli::otel::OtelConfig {
-        exporter: otel_exporter.map(|v| v.clone()),
+    let otel_config = crate::cli::otel::OtelConfig {
+        exporter: otel_exporter,
         endpoint: otel_exporter_endpoint.cloned(),
         protocol: otel_exporter_protocol.cloned(),
         enable_otel: Some(enable_otel),
         enable_traces: Some(enable_otel_traces),
         enable_logs: Some(enable_otel_logs),
         log_level,
-    });
-    let tracer_provider = init_logging(otel_config.unwrap());
+    };
+    let tracer_provider = init_logging(otel_config);
     let _tracer_provider_dropper;
-    if tracer_provider.is_some() {
-        let tracer_provider = tracer_provider.unwrap().clone();
-        _tracer_provider_dropper = crate::cli::otel::TracerProviderDropper(tracer_provider);
+    if let Some(tracer_provider) = &tracer_provider {
+        _tracer_provider_dropper = crate::cli::otel::TracerProviderDropper(tracer_provider.clone());
     }
     tracing::debug!("Starting application");
     let root = span!(tracing::Level::TRACE, "pact-cli", work_units = 2);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,7 @@ pub mod pact_broker_docker;
 pub mod pact_broker_ruby;
 
 pub fn build_cli() -> Command {
-    let app = Command::new("pact")
+    Command::new("pact")
         .about("🔗 Pact in a single binary - Mock/Stub Server, Provider Verifier, Broker Client & Plugin CLI")
         .long_about("
 
@@ -57,8 +57,7 @@ Contract testing with Pact lets you:
         .subcommand(pact_plugin_cli::Cli::command().name("plugin"))
         .subcommand(pact_mock_server_cli::setup_args().name("mock"))
         .subcommand(pact_verifier_cli::args::setup_app().name("verifier"))
-        .subcommand(pact_stub_server::build_args().name("stub"));
-    app
+        .subcommand(pact_stub_server::build_args().name("stub"))
 }
 
 fn add_completions_subcommand() -> Command {
@@ -67,7 +66,7 @@ fn add_completions_subcommand() -> Command {
     .arg(Arg::new("shell")
         .value_name("SHELL")
         .required(true)
-        .value_parser(clap::builder::PossibleValuesParser::new(&["bash", "fish", "zsh", "powershell", "elvish"]))
+        .value_parser(clap::builder::PossibleValuesParser::new(["bash", "fish", "zsh", "powershell", "elvish"]))
         .help("The shell to generate the script for"))
     .arg(Arg::new("dir")
         .short('d')
@@ -127,7 +126,7 @@ fn add_otel_options_args() -> Vec<Arg> {
             .default_value("http")
             .requires_if("otlp", "otel-exporter")
             .env("OTEL_EXPORTER_OTLP_PROTOCOL")
-            .value_parser(clap::builder::PossibleValuesParser::new(&[
+            .value_parser(clap::builder::PossibleValuesParser::new([
                 "http",
                 "http/protobuf",
             ])),

--- a/src/cli/extension.rs
+++ b/src/cli/extension.rs
@@ -328,18 +328,13 @@ impl ExtensionManager {
 
         let response = build_extension_client().get(&url).send().await?;
         if !response.status().is_success() {
-            return Err(format!(
-                "Failed to download pact-legacy: HTTP {}",
-                response.status()
-            )
-            .into());
+            return Err(
+                format!("Failed to download pact-legacy: HTTP {}", response.status()).into(),
+            );
         }
 
         let body = response.bytes().await?;
-        let archive_path = format!(
-            "{}/pact-legacy.{}",
-            self.extensions_home, archive_ext
-        );
+        let archive_path = format!("{}/pact-legacy.{}", self.extensions_home, archive_ext);
         let mut file = fs::File::create(&archive_path)?;
         file.write_all(&body)?;
         drop(file);
@@ -693,66 +688,66 @@ pub async fn run_extension_command(args: &ArgMatches) -> Result<(), Box<dyn std:
 
             // Fetch latest versions from APIs
             let latest_ruby_version = match manager.get_latest_ruby_standalone_version().await {
-            Ok(v) => v,
-            Err(_) => "unknown".to_string(),
+                Ok(v) => v,
+                Err(_) => "unknown".to_string(),
             };
             let latest_pactflow_ai_version = match manager.get_latest_pactflow_ai_version().await {
-            Ok(v) => v,
-            Err(_) => "unknown".to_string(),
+                Ok(v) => v,
+                Err(_) => "unknown".to_string(),
             };
 
             println!("📦 Available extensions:");
-            
+
             let mut table = comfy_table::Table::new();
             table
-            .set_header(vec!["Name", "Type", "Installed", "Latest", "Status"])
-            .set_content_arrangement(comfy_table::ContentArrangement::Dynamic);
+                .set_header(vec!["Name", "Type", "Installed", "Latest", "Status"])
+                .set_content_arrangement(comfy_table::ContentArrangement::Dynamic);
 
             for (name, config) in extensions {
-            if installed_only && !config.installed {
-                continue;
-            }
-
-            let ext_type = match config.extension_type {
-                ExtensionType::PactflowAi => "PactFlow AI",
-                ExtensionType::PactRubyStandalone => "Pact Legacy",
-                ExtensionType::External => "External",
-            };
-
-            let status = if config.installed {
-                "✅ Installed"
-            } else {
-                "❌ Not Installed"
-            };
-            let installed_version = if config.installed {
-                if matches!(config.extension_type, ExtensionType::PactflowAi) {
-                match manager.get_installed_pactflow_ai_version() {
-                    Ok(v) => v,
-                    Err(_) => "unknown".to_string(),
+                if installed_only && !config.installed {
+                    continue;
                 }
-                } else {
-                config.version.clone()
-                }
-            } else {
-                "-".to_string()
-            };
 
-            let latest_version =
-                if matches!(config.extension_type, ExtensionType::PactRubyStandalone) {
-                latest_ruby_version.clone()
-                } else if matches!(config.extension_type, ExtensionType::PactflowAi) {
-                latest_pactflow_ai_version.clone()
-                } else {
-                "-".to_string()
+                let ext_type = match config.extension_type {
+                    ExtensionType::PactflowAi => "PactFlow AI",
+                    ExtensionType::PactRubyStandalone => "Pact Legacy",
+                    ExtensionType::External => "External",
                 };
 
-            table.add_row(vec![
-                name,
-                ext_type.to_string(),
-                installed_version,
-                latest_version,
-                status.to_string(),
-            ]);
+                let status = if config.installed {
+                    "✅ Installed"
+                } else {
+                    "❌ Not Installed"
+                };
+                let installed_version = if config.installed {
+                    if matches!(config.extension_type, ExtensionType::PactflowAi) {
+                        match manager.get_installed_pactflow_ai_version() {
+                            Ok(v) => v,
+                            Err(_) => "unknown".to_string(),
+                        }
+                    } else {
+                        config.version.clone()
+                    }
+                } else {
+                    "-".to_string()
+                };
+
+                let latest_version =
+                    if matches!(config.extension_type, ExtensionType::PactRubyStandalone) {
+                        latest_ruby_version.clone()
+                    } else if matches!(config.extension_type, ExtensionType::PactflowAi) {
+                        latest_pactflow_ai_version.clone()
+                    } else {
+                        "-".to_string()
+                    };
+
+                table.add_row(vec![
+                    name,
+                    ext_type.to_string(),
+                    installed_version,
+                    latest_version,
+                    status.to_string(),
+                ]);
             }
 
             println!("{}", table);
@@ -843,41 +838,41 @@ pub async fn run_extension_command(args: &ArgMatches) -> Result<(), Box<dyn std:
             let all = sub_args.get_flag("all");
 
             if all {
-            let extensions = manager.list_extensions();
-            let mut installed_extensions: Vec<_> = extensions
-                .iter()
-                .filter(|(_, config)| config.installed)
-                .map(|(name, config)| (name.clone(), config.clone()))
-                .collect();
+                let extensions = manager.list_extensions();
+                let mut installed_extensions: Vec<_> = extensions
+                    .iter()
+                    .filter(|(_, config)| config.installed)
+                    .map(|(name, config)| (name.clone(), config.clone()))
+                    .collect();
 
-            // For PactRubyStandalone extensions, only keep the master entry
-            let mut ruby_found = false;
-            installed_extensions.retain(|(name, config)| {
-                if matches!(config.extension_type, ExtensionType::PactRubyStandalone) {
-                if !ruby_found && name == "pact-legacy" {
-                    ruby_found = true;
-                    true
-                } else {
-                    false
+                // For PactRubyStandalone extensions, only keep the master entry
+                let mut ruby_found = false;
+                installed_extensions.retain(|(name, config)| {
+                    if matches!(config.extension_type, ExtensionType::PactRubyStandalone) {
+                        if !ruby_found && name == "pact-legacy" {
+                            ruby_found = true;
+                            true
+                        } else {
+                            false
+                        }
+                    } else {
+                        true
+                    }
+                });
+
+                if installed_extensions.is_empty() {
+                    println!("⚠️  No extensions are currently installed.");
+                    return Ok(());
                 }
-                } else {
-                true
+
+                println!("🗑️  Uninstalling all extensions...");
+                for (ext_name, _) in installed_extensions {
+                    manager.uninstall_extension(&ext_name)?;
                 }
-            });
-
-            if installed_extensions.is_empty() {
-                println!("⚠️  No extensions are currently installed.");
-                return Ok(());
-            }
-
-            println!("🗑️  Uninstalling all extensions...");
-            for (ext_name, _) in installed_extensions {
-                manager.uninstall_extension(&ext_name)?;
-            }
             } else if let Some(ext_name) = extension {
-            manager.uninstall_extension(ext_name)?;
+                manager.uninstall_extension(ext_name)?;
             } else {
-            return Err("Please specify an extension name or use --all flag".into());
+                return Err("Please specify an extension name or use --all flag".into());
             }
         }
         Some((external_cmd, sub_args)) => {

--- a/src/cli/otel.rs
+++ b/src/cli/otel.rs
@@ -196,7 +196,7 @@ pub fn capture_telemetry(args: &[String], exit_code: i32, error_message: Option<
     let span_context = span.context();
     let otel_span = span_context.span();
 
-    if let Some(binary) = args.get(0) {
+    if let Some(binary) = args.first() {
         otel_span.set_attribute(KeyValue::new("binary", binary.clone()));
     }
     if let Some(command) = args.get(1) {

--- a/src/cli/pact_broker_docker.rs
+++ b/src/cli/pact_broker_docker.rs
@@ -11,20 +11,21 @@ pub fn add_docker_broker_subcommand() -> Command {
 pub fn run(args: &ArgMatches) -> Result<(), ExitCode> {
     match args.subcommand() {
         Some(("start", _args)) => {
-            let mut command_args = vec![];
-            command_args.push("run");
-            command_args.push("-d");
-            command_args.push("--name");
-            command_args.push("pact-broker");
-            command_args.push("-p");
-            command_args.push("9292:9292");
-            command_args.push("--env");
-            command_args.push("PACT_BROKER_PORT=9292");
-            command_args.push("--env");
-            command_args.push("PACT_BROKER_DATABASE_URL=sqlite:////tmp/pact_broker.sqlite");
-            command_args.push("--env");
-            command_args.push("'PACT_BROKER_BASE_URL=http://localhost http://localhost http://localhost:9292 http://pact-broker:9292 https://host.docker.internal http://host.docker.internal http://host.docker.internal:9292'");
-            command_args.push("pactfoundation/pact-broker:latest");
+            let command_args = vec![
+                "run",
+                "-d",
+                "--name",
+                "pact-broker",
+                "-p",
+                "9292:9292",
+                "--env",
+                "PACT_BROKER_PORT=9292",
+                "--env",
+                "PACT_BROKER_DATABASE_URL=sqlite:////tmp/pact_broker.sqlite",
+                "--env",
+                "'PACT_BROKER_BASE_URL=http://localhost http://localhost http://localhost:9292 http://pact-broker:9292 https://host.docker.internal http://host.docker.internal http://host.docker.internal:9292'",
+                "pactfoundation/pact-broker:latest",
+            ];
 
             println!(
                 "Starting Pact Broker Docker container with command: docker {}",

--- a/src/cli/pact_broker_ruby.rs
+++ b/src/cli/pact_broker_ruby.rs
@@ -273,7 +273,7 @@ pub fn run(args: &ArgMatches) -> Result<(), String> {
             let detach = args.get_flag("detach");
             if detach {
                 println!("🚀 Running in the background");
-                return Ok(());
+                Ok(())
             } else {
                 while child.try_wait().unwrap().is_none() {
                     std::thread::sleep(std::time::Duration::from_secs(1));
@@ -299,7 +299,7 @@ pub fn run(args: &ArgMatches) -> Result<(), String> {
                     }
                 }
                 let _ = fs::remove_file(&pid_file_path);
-                return Ok(());
+                Ok(())
             }
         }
         Some(("stop", _args)) => {


### PR DESCRIPTION
## What

Resolve latent `rustfmt` and `clippy` issues across the existing codebase. No behavioural change — every edit is a mechanical lint fix.

- **rustfmt** (5 diffs): re-wrapped `Err(format!(...))` / `format!` calls and re-indented blocks in `src/cli/extension.rs`.
- **clippy** (`-D warnings`):
  - `clippy::get_first` — `args.get(0)` → `args.first()` (`otel.rs`)
  - `clippy::needless_return` — dropped trailing `return` (`pact_broker_ruby.rs`)
  - `clippy::let_and_return` — return the builder directly (`cli.rs`)
  - `clippy::vec_init_then_push` — `vec![…]` literal (`pact_broker_docker.rs`)
  - needless borrows / redundant clones / unnecessary `Some(…).unwrap()` (`cli.rs`, `bin.rs`)

## Why

The PR-based release migration (#74) adds `cargo fmt --check` and `cargo clippy -- -D warnings` gates that the previous CI never ran, so these pre-existing issues were invisible. Landing them here keeps #74 focused purely on the release tooling; #74 will be rebased on top once this merges.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --tests --bins -- -D warnings` — clean (exit 0)
- `cargo nextest run` — 1 passed
