### PR TITLE
chore: release dry-run test (do not merge)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ codegen-units = 1
 cargo-dist-version = "0.32.0"
 ci = "github"
 allow-dirty = ["ci"]
+pr-run-mode = "upload"
 installers = ["shell", "powershell"]
 targets = [
   "aarch64-apple-darwin",


### PR DESCRIPTION
## ⚠️ Throwaway — do not merge

Disposable PR to validate the **cargo-dist release dry-run** (`plan` job in
`release.yml`) fires and passes on a fresh, minimal pull request — independent
of the migration PR (#74).

- Base is `feat/pr-based-release` so the diff is a single empty commit (a PR
  against `main` would duplicate all of #74's changes, since `main` doesn't
  have them yet).
- `test.yml` intentionally does not run here — by design it only triggers for
  PRs targeting `main`.
- `release-plz` does not run on PRs (only on push to `main`), so nothing is
  published.

Close and delete the branch once the `plan` check is green.
