### PR TITLE
chore(ci): add legacy-artifact publishing job

### DIFF
--- a/.github/workflows/legacy-artifacts.yml
+++ b/.github/workflows/legacy-artifacts.yml
@@ -1,0 +1,102 @@
+# Publishes loose binaries under the pre-cargo-dist naming convention
+# (pact-<old-os>[.exe]) alongside the cargo-dist archives, so consumers
+# still running the old install.sh/action.yml (unpinned, or pinned to an
+# action tag older than v0.10.3) don't 404 when "latest release" becomes
+# a cargo-dist release.
+#
+# TEMPORARY: this job self-disables (no-ops) on or after 2027-01-01 and
+# is safe to delete after that date — remove this file, drop
+# "./legacy-artifacts" from post-announce-jobs and the
+# "legacy-artifacts" entry from github-custom-job-permissions in
+# Cargo.toml, then run `dist generate`.
+#
+# See pact-foundation/pact-broker-cli's
+# docs/superpowers/specs/2026-07-01-legacy-artifact-compat-design.md,
+# which this job is ported from.
+
+name: Legacy Artifacts
+
+permissions:
+  contents: write
+
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to backfill legacy artifacts onto (e.g. v0.10.3)'
+        required: true
+        type: string
+
+jobs:
+  legacy-artifacts:
+    name: Publish Legacy-Named Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag
+        id: version
+        env:
+          PLAN: ${{ inputs.plan }}
+          MANUAL_TAG: ${{ inputs.tag }}
+        run: |
+          if [[ -n "$PLAN" ]]; then
+            TAG="$(echo "$PLAN" | jq -r '.announcement_tag')"
+          else
+            TAG="$MANUAL_TAG"
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Check cutoff date
+        id: cutoff
+        run: |
+          if [[ "$(date -u +%Y-%m-%d)" < "2027-01-01" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Past 2027-01-01 cutoff; skipping legacy artifact publishing." >&2
+          fi
+
+      - name: Repackage legacy-named binaries
+        if: steps.cutoff.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          workdir="$(mktemp -d)"
+          cd "$workdir"
+
+          targets=(
+            "aarch64-apple-darwin:pact-aarch64-macos:tar.xz"
+            "x86_64-apple-darwin:pact-x86_64-macos:tar.xz"
+            "aarch64-unknown-linux-gnu:pact-aarch64-linux-gnu:tar.xz"
+            "aarch64-unknown-linux-musl:pact-aarch64-linux-musl:tar.xz"
+            "x86_64-unknown-linux-gnu:pact-x86_64-linux-gnu:tar.xz"
+            "x86_64-unknown-linux-musl:pact-x86_64-linux-musl:tar.xz"
+            "x86_64-pc-windows-msvc:pact-x86_64-windows-msvc.exe:zip"
+          )
+
+          for entry in "${targets[@]}"; do
+            IFS=':' read -r target legacy_name archive_ext <<< "$entry"
+            archive="pact-${target}.${archive_ext}"
+
+            echo "::group::${target}"
+            gh release download "$TAG" --repo "${GITHUB_REPOSITORY}" -p "$archive" -O "$archive" --clobber
+
+            if [[ "$archive_ext" == "zip" ]]; then
+              unzip -q "$archive"
+              cp "pact.exe" "$legacy_name"
+            else
+              tar xJf "$archive"
+              cp "pact-${target}/pact" "$legacy_name"
+              chmod +x "$legacy_name"
+            fi
+
+            gh release upload "$TAG" "$legacy_name" --repo "${GITHUB_REPOSITORY}" --clobber
+            rm -rf "pact-${target}" "$archive"
+            echo "::endgroup::"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,3 +315,14 @@ jobs:
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
+
+  custom-legacy-artifacts:
+    needs:
+      - plan
+      - announce
+    uses: ./.github/workflows/legacy-artifacts.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+    permissions:
+      "contents": "write"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,14 @@
+#:tombi toml-version = "v1.0.0"
+
 [package]
 name = "pact"
 version = "0.10.4"
-authors = ["Yousaf Nabi <you@saf.dev>"]
 edition = "2021"
 description = "Pact consolidated CLI - pact_core_mock_server, pact_verifier, pact-stub-server, pact-plugin-cli, pact-broker-cli in a single binary"
+readme = "README.md"
 homepage = "https://www.pact.io"
 repository = "https://github.com/pact-foundation/pact-cli"
-readme = "README.md"
+license = "MIT"
 keywords = [
   "pact-broker-client",
   "pact-mock-server",
@@ -14,7 +16,6 @@ keywords = [
   "pact-stub-server",
   "pact-verifier"
 ]
-license = "MIT"
 include = [
   "/README.md",
   "CHANGELOG.md",
@@ -25,6 +26,29 @@ include = [
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace.metadata.dist]
+cargo-dist-version = "0.32.0"
+ci = "github"
+installers = ["shell", "powershell"]
+targets = [
+  "aarch64-apple-darwin",
+  # Waiting for https://github.com/briansmith/ring/pull/2803 to be released
+  # "aarch64-pc-windows-msvc",
+  "aarch64-unknown-linux-gnu",
+  "aarch64-unknown-linux-musl",
+  "x86_64-apple-darwin",
+  "x86_64-pc-windows-msvc",
+  "x86_64-unknown-linux-gnu",
+  "x86_64-unknown-linux-musl",
+]
+install-path = "~/.pact/bin"
+post-announce-jobs = [
+  "./publish-containers",
+  "./notify-homebrew",
+  "./legacy-artifacts"
+]
+github-custom-job-permissions = { publish-containers = { contents = "read", packages = "write" }, legacy-artifacts = { contents = "write" } }
 
 [[bin]]
 name = "pact"
@@ -76,32 +100,6 @@ tracing-subscriber = { version = "0.3.20", features = [
 
 [dev-dependencies]
 trycmd = "=1.2.0"
-
-[profile.release]
-opt-level = "z"  # Optimize for size.
-strip = true  # Automatically strip symbols from the binary.
-lto = true
-panic = "abort"
-codegen-units = 1
-
-[workspace.metadata.dist]
-cargo-dist-version = "0.32.0"
-ci = "github"
-installers = ["shell", "powershell"]
-targets = [
-  "aarch64-apple-darwin",
-  # Waiting for https://github.com/briansmith/ring/pull/2803 to be released
-  # "aarch64-pc-windows-msvc",
-  "aarch64-unknown-linux-gnu",
-  "aarch64-unknown-linux-musl",
-  "x86_64-apple-darwin",
-  "x86_64-pc-windows-msvc",
-  "x86_64-unknown-linux-gnu",
-  "x86_64-unknown-linux-musl",
-]
-install-path = "~/.pact/bin"
-post-announce-jobs = ["./publish-containers", "./notify-homebrew"]
-github-custom-job-permissions = { publish-containers = { contents = "read", packages = "write" } }
 
 [profile.dist]
 inherits = "release"


### PR DESCRIPTION
## Summary
- Ports the legacy-artifact-compat fix from pact-foundation/pact-broker-cli to this repo: v0.10.3 was the first cargo-dist release and no longer publishes loose `pact-<old-os>[.exe]` binaries, breaking unpinned/old-pinned consumers of `install.sh`/`action.yml`.
- Adds `.github/workflows/legacy-artifacts.yml` (temporary, self-disables 2027-01-01), wired into `release.yml` via `post-announce-jobs` in `Cargo.toml`, regenerated with `dist generate`.
- Verified zip/tar.xz archive internals against real v0.10.3 assets before writing the repackage logic (this repo's cargo-dist output matches pact-broker-cli's: zip contents at archive root, tar.xz contents under `<stem>/`).

## Test plan
- [x] `actionlint` clean on both workflow files (pre-existing shellcheck warnings on unrelated `release.yml` lines confirmed unchanged)
- [x] `dist generate` diff to `release.yml` is a clean, additive `custom-legacy-artifacts` job block only
- [ ] Dispatch `legacy-artifacts.yml` from this branch against `v0.10.3` to verify before merge
- [ ] After merge, backfill `v0.10.3` and `v0.10.4` (the only two cargo-dist releases so far)